### PR TITLE
Ignore schemas

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -109,6 +109,11 @@ export interface PostGraphileOptions<
   // from the generated GraphQL schema as general applications don't need them
   // to be exposed to the end user. You can use this flag to include them in
   // the generated schema (not recommended).
+  ignoreSchemas?: boolean;
+  // Not recommended. By default, database objects within generated queries
+  // consist of the PostgreSQL schema name and table name separated by a dot.
+  // Set 'true' to omit the schema name, such that relevant table is determined
+  // based on the current search_path.  Useful in multi-tenant applications.
   includeExtensionResources?: boolean;
   // Enables adding a `stack` field to the error response.  Can be either the
   // boolean `true` (which results in a single stack string) or the string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -105,15 +105,15 @@ export interface PostGraphileOptions<
   // recommend you start with it set to `false`.
   // The default is `true`, in v5 the default may change to `false`.
   ignoreIndexes?: boolean;
-  // By default, tables and functions that come from extensions are excluded
-  // from the generated GraphQL schema as general applications don't need them
-  // to be exposed to the end user. You can use this flag to include them in
-  // the generated schema (not recommended).
-  ignoreSchemas?: boolean;
   // Not recommended. By default, database objects within generated queries
   // consist of the PostgreSQL schema name and table name separated by a dot.
   // Set 'true' to omit the schema name, such that relevant table is determined
   // based on the current search_path.  Useful in multi-tenant applications.
+  ignoreSchemas?: boolean;
+  // By default, tables and functions that come from extensions are excluded
+  // from the generated GraphQL schema as general applications don't need them
+  // to be exposed to the end user. You can use this flag to include them in
+  // the generated schema (not recommended).
   includeExtensionResources?: boolean;
   // Enables adding a `stack` field to the error response.  Can be either the
   // boolean `true` (which results in a single stack string) or the string


### PR DESCRIPTION
Per graphile/postgraphile #191, creates an ignoreSchemas (default: false) configuration option to disable automatic prepending of the schema name to the table name. In the case of multi-tenant applications (where there's a schema per tenant), search_path can instead be supplied via the callback to pgSettings based on the inbound JWT.